### PR TITLE
feat(contract,eval): add RunConfig execution engine and Evaluation Hi…

### DIFF
--- a/cmd/hyp/eval_report.go
+++ b/cmd/hyp/eval_report.go
@@ -1,0 +1,260 @@
+package main
+
+// @ai purpose: hyp eval-report CLI 命令 — 讀取 .hyp/eval_history.jsonl，以趨勢表格呈現各路由的測試品質演進
+// @ai input: 可選的 --path（自訂 history 檔案路徑）、--n（最近 N 筆的平均視窗）
+// @ai output: 終端趨勢報告（route | last N avg | trend | flaky detection）
+// @ai sideeffect: 讀取 .hyp/eval_history.jsonl
+// date: 2026-05-23
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/maoxiaoyue/hypgo/pkg/eval"
+	"github.com/spf13/cobra"
+)
+
+var evalReportCmd = &cobra.Command{
+	Use:   "eval-report",
+	Short: "Show contract test quality trend from eval history",
+	Long: `Read .hyp/eval_history.jsonl and display a quality trend report for each route.
+
+The report shows:
+  - Route path (METHOD /path)
+  - Average contract score over the last N runs (default: 5)
+  - Trend vs. the previous N runs (↑ improving / ↓ degrading / → stable)
+  - Flaky detection: routes that alternate between pass and fail
+  - Warning ⚠ for routes where score dropped more than 0.1
+
+History is generated automatically when using:
+  contract.TestAll(t, router, contract.RunConfig{RecordHistory: true})
+
+Examples:
+  hyp eval-report                       # read .hyp/eval_history.jsonl
+  hyp eval-report --path my/history.jsonl
+  hyp eval-report --n 10                # average over last 10 runs`,
+	RunE: runEvalReport,
+}
+
+var (
+	evalReportPath string
+	evalReportN    int
+)
+
+func init() {
+	evalReportCmd.Flags().StringVar(&evalReportPath, "path", eval.DefaultHistoryPath(),
+		"Path to the eval history JSONL file")
+	evalReportCmd.Flags().IntVar(&evalReportN, "n", 5,
+		"Number of recent runs to average for the trend window")
+}
+
+// runEvalReport 執行 eval-report 命令：讀取 history 並輸出趨勢表格
+func runEvalReport(cmd *cobra.Command, args []string) error {
+	if evalReportN < 1 {
+		return fmt.Errorf("--n must be >= 1, got %d", evalReportN)
+	}
+
+	records, err := eval.LoadHistory(evalReportPath)
+	if err != nil {
+		return fmt.Errorf("讀取 eval history 失敗: %w", err)
+	}
+
+	if len(records) == 0 {
+		fmt.Println("📋 尚無 eval 記錄。")
+		fmt.Println()
+		fmt.Println("啟用歷史記錄：")
+		fmt.Println(`  contract.TestAll(t, r, contract.RunConfig{RecordHistory: true})`)
+		fmt.Println()
+		fmt.Printf("記錄儲存位置：%s\n", evalReportPath)
+		return nil
+	}
+
+	// 按路由分組
+	byRoute := groupByRoute(records)
+
+	// 取得所有路由並排序（固定輸出順序）
+	routes := make([]string, 0, len(byRoute))
+	for r := range byRoute {
+		routes = append(routes, r)
+	}
+	sort.Strings(routes)
+
+	// 輸出報告頭
+	fmt.Printf("📊 Eval Report — %s\n", evalReportPath)
+	fmt.Printf("   Total records: %d  |  Routes: %d  |  Window: last %d\n\n",
+		len(records), len(routes), evalReportN)
+
+	// 使用 tabwriter 對齊欄位
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "Route\tLast N avg\tPrev N avg\tTrend\tFlaky\tRuns")
+	fmt.Fprintln(w, "─────\t──────────\t──────────\t─────\t─────\t────")
+
+	var hasWarning bool
+	for _, route := range routes {
+		recs := byRoute[route]
+
+		n := evalReportN
+		lastAvg := windowAvg(recs, 0, n)
+		prevAvg := windowAvg(recs, n, 2*n)
+		flaky := isFlaky(recs, n)
+		trend := trendArrow(lastAvg, prevAvg)
+		warn := ""
+		if prevAvg >= 0 && lastAvg < prevAvg-0.1 {
+			warn = " ⚠"
+			hasWarning = true
+		}
+
+		lastStr := formatScore(lastAvg)
+		prevStr := formatScore(prevAvg)
+
+		flakyStr := ""
+		if flaky {
+			flakyStr = "⚡"
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s%s\t%s\t%d\n",
+			route, lastStr, prevStr, trend, warn, flakyStr, len(recs))
+	}
+	w.Flush()
+
+	if hasWarning {
+		fmt.Println()
+		fmt.Println("⚠ = score dropped more than 0.1 vs previous window")
+	}
+
+	// 最後記錄的 git commit
+	if len(records) > 0 {
+		last := records[len(records)-1]
+		if last.GitCommit != "" {
+			fmt.Printf("\nLast recorded commit: %s\n", last.GitCommit)
+		}
+	}
+
+	return nil
+}
+
+// groupByRoute 將 []EvalRecord 按 Route 欄位分組，組內保持時間先後順序
+func groupByRoute(records []eval.EvalRecord) map[string][]eval.EvalRecord {
+	result := make(map[string][]eval.EvalRecord)
+	for _, r := range records {
+		result[r.Route] = append(result[r.Route], r)
+	}
+	return result
+}
+
+// windowAvg 計算 records 中倒數第 (skip+n) 到倒數第 skip 筆的平均 contract score
+// skip=0,n=5 → last 5；skip=5,n=5 → previous 5
+// 若無足夠記錄回傳 -1（表示 N/A）
+func windowAvg(records []eval.EvalRecord, skip, end int) float64 {
+	total := len(records)
+	// 計算實際的倒數範圍
+	from := total - end
+	to := total - skip
+	if from < 0 {
+		from = 0
+	}
+	if to <= from {
+		return -1
+	}
+
+	window := records[from:to]
+	if len(window) == 0 {
+		return -1
+	}
+
+	var sum float64
+	var count int
+	for _, r := range window {
+		if score, ok := r.Scores["contract"]; ok {
+			sum += score
+			count++
+		} else {
+			// 無 scores 欄位：由 status 推斷
+			if r.Status == "pass" {
+				sum++
+			}
+			count++
+		}
+	}
+	if count == 0 {
+		return -1
+	}
+	return sum / float64(count)
+}
+
+// isFlaky 偵測最近 N 筆記錄中是否有「通過/失敗交替」模式（flaky test）
+// 若同一路由在最近 N 筆中同時有 pass 和 fail，視為 flaky
+func isFlaky(records []eval.EvalRecord, n int) bool {
+	from := len(records) - n
+	if from < 0 {
+		from = 0
+	}
+	window := records[from:]
+	if len(window) < 2 {
+		return false
+	}
+
+	hasPass, hasFail := false, false
+	for _, r := range window {
+		if r.Status == "pass" {
+			hasPass = true
+		} else {
+			hasFail = true
+		}
+		if hasPass && hasFail {
+			return true
+		}
+	}
+	return false
+}
+
+// trendArrow 依據最近與前期平均分數，回傳趨勢符號
+func trendArrow(last, prev float64) string {
+	if prev < 0 {
+		// 前期無資料
+		return "→ new"
+	}
+	diff := last - prev
+	switch {
+	case math.Abs(diff) < 0.02:
+		return fmt.Sprintf("→ stable")
+	case diff > 0:
+		return fmt.Sprintf("↑ +%.2f", diff)
+	default:
+		return fmt.Sprintf("↓ %.2f", diff)
+	}
+}
+
+// formatScore 將 -1（N/A）或 0–1 的分數格式化為字串
+func formatScore(score float64) string {
+	if score < 0 {
+		return "N/A"
+	}
+	return fmt.Sprintf("%.2f", score)
+}
+
+// truncateRoute 截短過長的路由字串，讓表格不會過寬
+func truncateRoute(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-3] + "..."
+}
+
+// filterByRoute 過濾只保留特定路由的記錄（供未來 --filter flag 使用）
+func filterByRoute(records []eval.EvalRecord, filter string) []eval.EvalRecord {
+	if filter == "" {
+		return records
+	}
+	var result []eval.EvalRecord
+	for _, r := range records {
+		if strings.Contains(strings.ToLower(r.Route), strings.ToLower(filter)) {
+			result = append(result, r)
+		}
+	}
+	return result
+}

--- a/cmd/hyp/main.go
+++ b/cmd/hyp/main.go
@@ -21,6 +21,7 @@ AI Collaboration:
 
 Testing:
   observe        List or open contract observe HTML reports
+  eval-report    Show contract test quality trend from .hyp/eval_history.jsonl
 
 Project Management:
   new / api      Create full-stack or API-only project
@@ -105,6 +106,7 @@ Examples:
 	rootCmd.AddCommand(chkcommentCmd)
 	rootCmd.AddCommand(impactCmd)
 	rootCmd.AddCommand(observeCmd)
+	rootCmd.AddCommand(evalReportCmd)
 }
 
 // Execute 允許其他包執行根命令

--- a/pkg/contract/contract.go
+++ b/pkg/contract/contract.go
@@ -3,11 +3,21 @@
 // 確保 AI 生成的程式碼符合宣告的合約
 package contract
 
+// @ai purpose: Contract Testing 核心 — Test / TestAll / TestRoute 三個公開測試函式
+// @ai input: *testing.T、*router.Router、TestCase / RunConfig
+// @ai output: 無（透過 t.Errorf / t.Skip 回報結果）
+// @ai sideeffect: 呼叫 router.ServeHTTP（httptest 模式，不開真實 port）
+// date: 2026-05-23
+
 import (
+	"fmt"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/maoxiaoyue/hypgo/pkg/eval"
 	"github.com/maoxiaoyue/hypgo/pkg/router"
 	"github.com/maoxiaoyue/hypgo/pkg/schema"
 )
@@ -40,29 +50,37 @@ type TestCase struct {
 }
 
 // Test 執行單一 contract 測試
+//
+// @ai purpose: 手動執行單一路由的 contract 驗證，適合邊界條件與錯誤路徑測試
+// @ai input: *testing.T、*router.Router、TestCase（完整定義）
+// @ai output: 無
+// @ai sideeffect: 呼叫 t.Errorf / t.Fatalf
+// date: 2026-05-23
 func Test(t *testing.T, r *router.Router, tc TestCase) {
 	t.Helper()
 	testInternal(t, r, tc)
 }
 
-// testInternal 為內部共用實作
-func testInternal(t *testing.T, r *router.Router, tc TestCase) {
-	t.Helper()
-
+// runTestOnce 執行一次 contract 測試並回傳結果，不接觸 *testing.T
+// 這是純執行函式，讓重試迴圈可以多次呼叫而不污染 t 的狀態
+//
+// @ai purpose: 將 HTTP 執行邏輯與 t.Errorf 解耦，支援 TestAll 的重試機制
+// @ai input: *router.Router（被測路由器）、TestCase（測試定義）
+// @ai output: pass bool（是否通過）、reason string（失敗原因，pass=true 時為空字串）
+// @ai sideeffect: 無（不呼叫任何 t.* 方法）
+// date: 2026-05-23
+func runTestOnce(r *router.Router, tc TestCase) (pass bool, reason string) {
 	method, path := parseRoute(tc.Route)
 	if method == "" || path == "" {
-		t.Fatalf("invalid route format: %q (expected \"METHOD /path\")", tc.Route)
+		return false, fmt.Sprintf("invalid route format: %q (expected \"METHOD /path\")", tc.Route)
 	}
 
-	// 建立請求
-	var body *strings.Reader
+	// 建立請求 body
+	var bodyStr string
 	if tc.Input != "" {
-		body = strings.NewReader(tc.Input)
-	} else {
-		body = strings.NewReader("")
+		bodyStr = tc.Input
 	}
-
-	req := httptest.NewRequest(method, path, body)
+	req := httptest.NewRequest(method, path, strings.NewReader(bodyStr))
 	if tc.Input != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -87,7 +105,7 @@ func testInternal(t *testing.T, r *router.Router, tc TestCase) {
 
 	// 驗證狀態碼
 	if tc.ExpectStatus > 0 && w.Code != tc.ExpectStatus {
-		t.Errorf("[%s] status = %d, want %d", tc.Route, w.Code, tc.ExpectStatus)
+		return false, fmt.Sprintf("[%s] status = %d, want %d", tc.Route, w.Code, tc.ExpectStatus)
 	}
 
 	// 驗證 schema（使用 schemaPath 或 URL path 查找）
@@ -98,19 +116,18 @@ func testInternal(t *testing.T, r *router.Router, tc TestCase) {
 		}
 		s, ok := schema.Global().Get(method, lookupPath)
 		if !ok {
-			t.Errorf("[%s] no schema registered for validation", tc.Route)
-		} else {
-			// 驗證 Input schema（請求 body）
-			if s.Input != nil && tc.Input != "" {
-				if err := validateRequest([]byte(tc.Input), s.Input); err != nil {
-					t.Errorf("[%s] request schema validation failed: %v", tc.Route, err)
-				}
+			return false, fmt.Sprintf("[%s] no schema registered for validation", tc.Route)
+		}
+		// 驗證 Input schema（請求 body）
+		if s.Input != nil && tc.Input != "" {
+			if err := validateRequest([]byte(tc.Input), s.Input); err != nil {
+				return false, fmt.Sprintf("[%s] request schema validation failed: %v", tc.Route, err)
 			}
-			// 驗證 Output schema（回應 body）
-			if s.Output != nil {
-				if err := validateResponse(w.Body.Bytes(), s.Output); err != nil {
-					t.Errorf("[%s] response schema validation failed: %v", tc.Route, err)
-				}
+		}
+		// 驗證 Output schema（回應 body）
+		if s.Output != nil {
+			if err := validateResponse(w.Body.Bytes(), s.Output); err != nil {
+				return false, fmt.Sprintf("[%s] response schema validation failed: %v", tc.Route, err)
 			}
 		}
 	}
@@ -120,38 +137,168 @@ func testInternal(t *testing.T, r *router.Router, tc TestCase) {
 		got := strings.TrimSpace(w.Body.String())
 		want := strings.TrimSpace(tc.ExpectBody)
 		if got != want {
-			t.Errorf("[%s] body = %q, want %q", tc.Route, got, want)
+			return false, fmt.Sprintf("[%s] body = %q, want %q", tc.Route, got, want)
 		}
+	}
+
+	return true, ""
+}
+
+// testInternal 為 Test() 的內部共用實作
+// 呼叫 runTestOnce 並將失敗結果報告至 t.Errorf
+//
+// @ai purpose: 橋接純執行函式（runTestOnce）與 testing.T 回報機制
+// @ai input: *testing.T、*router.Router、TestCase
+// @ai output: 無
+// @ai sideeffect: 呼叫 t.Errorf / t.Fatalf
+// date: 2026-05-23
+func testInternal(t *testing.T, r *router.Router, tc TestCase) {
+	t.Helper()
+	pass, reason := runTestOnce(r, tc)
+	if !pass {
+		t.Errorf("contract: %s", reason)
 	}
 }
 
 // TestAll 自動測試所有 schema-registered 路由
 // REST 路由：發送 HTTP 請求並驗證 Input/Output
 // 非 REST 路由：驗證 schema 定義完整性（不發送請求）
-func TestAll(t *testing.T, r *router.Router) {
+//
+// 可選傳入 RunConfig 啟用並行、重試、速率限制、FailFast 與 History 記錄：
+//
+//	contract.TestAll(t, r)                              // 向後相容，循序執行
+//	contract.TestAll(t, r, contract.RunConfig{
+//	    Parallel: true, MaxWorkers: 4, RetryCount: 2,
+//	    RecordHistory: true,                            // append 到 .hyp/eval_history.jsonl
+//	})
+//
+// @ai purpose: 一鍵驗證所有 schema-registered 路由的 contract，支援執行引擎設定與歷史記錄
+// @ai input: *testing.T、*router.Router、可選的 RunConfig（向後相容）
+// @ai output: 無
+// @ai sideeffect: 呼叫 t.Run / t.Parallel / t.Errorf / t.Logf / t.Skip；RecordHistory=true 時 append .hyp/eval_history.jsonl
+// date: 2026-05-23
+func TestAll(t *testing.T, r *router.Router, cfgs ...RunConfig) {
 	t.Helper()
+
+	cfg := mergeRunConfig(cfgs)
 
 	routes := schema.Global().All()
 	if len(routes) == 0 {
 		t.Skip("no schema-registered routes found")
 	}
 
+	// FailFast 信號：atomic 確保 goroutine 間無鎖可見
+	var aborted atomic.Bool
+
+	// 速率限制器：由所有子測試 goroutine 共享競爭接收（goroutine-safe）
+	var limiterCh <-chan time.Time
+	if cfg.RateLimit > 0 {
+		ticker := time.NewTicker(time.Second / time.Duration(cfg.RateLimit))
+		limiterCh = ticker.C
+		// t.Cleanup 確保 ticker 在所有並行子測試完成後才停止
+		t.Cleanup(ticker.Stop)
+	}
+
+	// git commit hash：只在 RecordHistory=true 時查詢，且只查詢一次
+	var gitCommit string
+	if cfg.RecordHistory {
+		gitCommit = eval.GitShortCommit()
+	}
+
 	for _, route := range routes {
-		route := route // capture
+		route := route // capture for goroutine / closure
 
 		if route.IsREST() {
-			// REST 路由：完整的 HTTP 測試
 			name := route.Method + " " + route.Path
 			t.Run(name, func(t *testing.T) {
+				// FailFast 檢查：並行模式下在 t.Parallel() 後仍需檢查
+				if aborted.Load() {
+					t.Skip("skipped: FailFast abort")
+					return
+				}
+
+				if cfg.Parallel {
+					t.Parallel()
+				}
+
+				// 並行模式下，goroutine 重新啟動後再次檢查
+				if aborted.Load() {
+					t.Skip("skipped: FailFast abort")
+					return
+				}
+
+				// 速率限制：所有 goroutine 競爭接收同一個 ticker channel
+				if cfg.RateLimit > 0 {
+					<-limiterCh
+				}
+
 				tc := generateTestCase(route)
 				tc.schemaPath = route.Path
-				testInternal(t, r, tc)
+
+				// 重試迴圈（含計時，用於 RecordHistory）
+				start := time.Now()
+				var pass bool
+				var reason string
+				for attempt := 0; attempt <= cfg.RetryCount; attempt++ {
+					if attempt > 0 {
+						t.Logf("[retry %d/%d] %s %s", attempt, cfg.RetryCount,
+							route.Method, route.Path)
+						if cfg.RetryDelay > 0 {
+							time.Sleep(cfg.RetryDelay)
+						}
+					}
+					pass, reason = runTestOnce(r, tc)
+					if pass {
+						break
+					}
+				}
+				latencyMs := time.Since(start).Milliseconds()
+
+				if !pass {
+					t.Errorf("contract: %s", reason)
+					if cfg.FailFast {
+						aborted.Store(true)
+					}
+				}
+
+				// 歷史記錄：RecordHistory=true 時 append 結果
+				if cfg.RecordHistory {
+					score := 0.0
+					if pass {
+						score = 1.0
+					}
+					status := "fail"
+					if pass {
+						status = "pass"
+					}
+					_ = eval.AppendHistory(eval.EvalRecord{
+						Timestamp:  time.Now().UTC(),
+						GitCommit:  gitCommit,
+						Route:      route.Method + " " + route.Path,
+						Status:     status,
+						Scores:     map[string]float64{"contract": score},
+						LatencyMs:  latencyMs,
+						InputHash:  eval.HashInput(tc.Input),
+						FailReason: reason,
+					})
+				}
 			})
 		} else {
 			// 非 REST 路由：驗證 schema 定義完整性
 			name := route.Protocol + "|" + route.Command
 			t.Run(name, func(t *testing.T) {
+				if aborted.Load() {
+					t.Skip("skipped: FailFast abort")
+					return
+				}
+				if cfg.Parallel {
+					t.Parallel()
+				}
 				testSchemaCompleteness(t, route)
+				// FailFast：testSchemaCompleteness 失敗後設定 aborted
+				if t.Failed() && cfg.FailFast {
+					aborted.Store(true)
+				}
 			})
 		}
 	}
@@ -159,6 +306,12 @@ func TestAll(t *testing.T, r *router.Router) {
 
 // testSchemaCompleteness 驗證非 REST 路由的 schema 定義完整性
 // 不發送實際請求，只檢查 schema 本身的品質
+//
+// @ai purpose: 對 gRPC / Bot / MCP / WebSocket / CLI 路由做 schema 品質檢查
+// @ai input: *testing.T、schema.Route（非 REST 路由）
+// @ai output: 無
+// @ai sideeffect: 呼叫 t.Errorf
+// date: 2026-05-23
 func testSchemaCompleteness(t *testing.T, route schema.Route) {
 	t.Helper()
 
@@ -181,6 +334,12 @@ func testSchemaCompleteness(t *testing.T, route schema.Route) {
 }
 
 // TestRoute 測試單一路由是否已註冊且可回應
+//
+// @ai purpose: 簡易路由存在性驗證，不需要 schema 宣告
+// @ai input: *testing.T、*router.Router、method string、path string、expectStatus int
+// @ai output: 無
+// @ai sideeffect: 呼叫 t.Errorf
+// date: 2026-05-23
 func TestRoute(t *testing.T, r *router.Router, method, path string, expectStatus int) {
 	t.Helper()
 
@@ -194,6 +353,12 @@ func TestRoute(t *testing.T, r *router.Router, method, path string, expectStatus
 }
 
 // parseRoute 解析 "METHOD /path" 格式
+//
+// @ai purpose: 內部工具函式，將 TestCase.Route 字串拆分為 method 和 path
+// @ai input: route string（格式 "METHOD /path"）
+// @ai output: method string、path string（格式不正確時均為空字串）
+// @ai sideeffect: 無
+// date: 2026-05-23
 func parseRoute(route string) (method, path string) {
 	parts := strings.SplitN(route, " ", 2)
 	if len(parts) != 2 {

--- a/pkg/contract/engine.go
+++ b/pkg/contract/engine.go
@@ -1,0 +1,74 @@
+package contract
+
+// @ai purpose: RunConfig 執行引擎設定 — 集中管理 TestAll / ObserveAll / Observe 的並行、重試、速率限制與 FailFast 策略
+// @ai input: 無（僅定義型別與工具函式，由 TestAll / runObserve 呼叫）
+// @ai output: RunConfig 型別、mergeRunConfig() 正規化函式
+// @ai sideeffect: 無
+// date: 2026-05-23
+
+import (
+	"runtime"
+	"time"
+)
+
+// RunConfig 控制 TestAll / ObserveAll / Observe 的執行策略
+//
+// 零值等同於原有行為（循序、不重試、不限速、不 FailFast），保持向後相容。
+//
+// 使用範例：
+//
+//	contract.TestAll(t, r, contract.RunConfig{
+//	    Parallel:   true,
+//	    MaxWorkers: 4,
+//	    RetryCount: 2,
+//	    RetryDelay: 500 * time.Millisecond,
+//	    RateLimit:  10,
+//	    FailFast:   false,
+//	})
+type RunConfig struct {
+	// Parallel 啟用並行執行
+	// TestAll 使用 t.Parallel()，ObserveAll/Observe 使用 goroutine pool
+	Parallel bool
+
+	// MaxWorkers 限制並行 goroutine 數量
+	// 0 或負值 → 自動設為 runtime.GOMAXPROCS(0)
+	MaxWorkers int
+
+	// RetryCount 失敗後的額外重試次數（0 = 不重試）
+	// 例如 RetryCount=2 表示最多執行 3 次（1 次初始 + 2 次重試）
+	RetryCount int
+
+	// RetryDelay 每次重試前的等待時間（0 = 立即重試）
+	RetryDelay time.Duration
+
+	// RateLimit 每秒最大執行數（0 = 不限制）
+	// 使用 time.Ticker 實作，多個 goroutine 競爭接收，天然 goroutine-safe
+	RateLimit int
+
+	// FailFast 第一個失敗後立即停止後續測試
+	// 並行模式下：已啟動的 goroutine 會繼續完成，新的不再啟動
+	FailFast bool
+
+	// RecordHistory 將每次測試結果 append 到 .hyp/eval_history.jsonl
+	// true 時自動記錄（含路由、狀態、延遲、git commit、輸入 hash）
+	// false 時不記錄（零值，向後相容）
+	RecordHistory bool
+}
+
+// mergeRunConfig 取第一個 RunConfig 或回傳零值，並正規化 MaxWorkers
+//
+// @ai purpose: 讓 TestAll(t, r) 零引數呼叫繼續向後相容，並確保 MaxWorkers 非零
+// @ai input: []RunConfig（可為空或 nil）
+// @ai output: 單一正規化的 RunConfig
+// @ai sideeffect: 無
+// date: 2026-05-23
+func mergeRunConfig(cfgs []RunConfig) RunConfig {
+	var cfg RunConfig
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	if cfg.MaxWorkers <= 0 {
+		cfg.MaxWorkers = runtime.GOMAXPROCS(0)
+	}
+	return cfg
+}

--- a/pkg/contract/engine_test.go
+++ b/pkg/contract/engine_test.go
@@ -1,0 +1,501 @@
+package contract
+
+// @ai purpose: engine_test — 驗證 RunConfig 執行引擎的並行、重試、速率限制、FailFast、RecordHistory 與向後相容性
+// @ai input: *testing.T
+// @ai output: 無
+// @ai sideeffect: 在測試暫存目錄中可能建立 .hyp/ 目錄與 HTML 報告；RecordHistory 測試寫入 eval_history.jsonl
+// date: 2026-05-23
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	hypcontext "github.com/maoxiaoyue/hypgo/pkg/context"
+	"github.com/maoxiaoyue/hypgo/pkg/eval"
+	"github.com/maoxiaoyue/hypgo/pkg/router"
+	"github.com/maoxiaoyue/hypgo/pkg/schema"
+)
+
+// ─── mergeRunConfig ──────────────────────────────────────────────────────────
+
+func TestMergeRunConfig_Defaults(t *testing.T) {
+	cfg := mergeRunConfig(nil)
+	if cfg.MaxWorkers != runtime.GOMAXPROCS(0) {
+		t.Errorf("MaxWorkers default = %d, want GOMAXPROCS = %d",
+			cfg.MaxWorkers, runtime.GOMAXPROCS(0))
+	}
+	if cfg.Parallel {
+		t.Error("Parallel should default to false")
+	}
+	if cfg.FailFast {
+		t.Error("FailFast should default to false")
+	}
+	if cfg.RetryCount != 0 {
+		t.Errorf("RetryCount default = %d, want 0", cfg.RetryCount)
+	}
+	if cfg.RateLimit != 0 {
+		t.Errorf("RateLimit default = %d, want 0", cfg.RateLimit)
+	}
+}
+
+func TestMergeRunConfig_ExplicitValues(t *testing.T) {
+	cfg := mergeRunConfig([]RunConfig{{
+		Parallel:   true,
+		MaxWorkers: 2,
+		RetryCount: 3,
+		RetryDelay: 100 * time.Millisecond,
+		RateLimit:  5,
+		FailFast:   true,
+	}})
+	if !cfg.Parallel {
+		t.Error("Parallel should be true")
+	}
+	if cfg.MaxWorkers != 2 {
+		t.Errorf("MaxWorkers = %d, want 2", cfg.MaxWorkers)
+	}
+	if cfg.RetryCount != 3 {
+		t.Errorf("RetryCount = %d, want 3", cfg.RetryCount)
+	}
+	if cfg.RetryDelay != 100*time.Millisecond {
+		t.Errorf("RetryDelay = %v, want 100ms", cfg.RetryDelay)
+	}
+	if cfg.RateLimit != 5 {
+		t.Errorf("RateLimit = %d, want 5", cfg.RateLimit)
+	}
+	if !cfg.FailFast {
+		t.Error("FailFast should be true")
+	}
+}
+
+func TestMergeRunConfig_ZeroMaxWorkers_GetsGOMAXPROCS(t *testing.T) {
+	cfg := mergeRunConfig([]RunConfig{{Parallel: true, MaxWorkers: 0}})
+	if cfg.MaxWorkers != runtime.GOMAXPROCS(0) {
+		t.Errorf("zero MaxWorkers should become GOMAXPROCS=%d, got %d",
+			runtime.GOMAXPROCS(0), cfg.MaxWorkers)
+	}
+}
+
+// ─── runTestOnce（純函式驗證）────────────────────────────────────────────────
+
+func TestRunTestOnce_PassOnValidRoute(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+	r.GET("/ping", func(c *hypcontext.Context) {
+		c.JSON(200, map[string]string{"status": "ok"})
+	})
+
+	pass, reason := runTestOnce(r, TestCase{
+		Route:        "GET /ping",
+		ExpectStatus: 200,
+	})
+	if !pass {
+		t.Errorf("runTestOnce should pass, reason: %s", reason)
+	}
+	if reason != "" {
+		t.Errorf("reason should be empty on success, got %q", reason)
+	}
+}
+
+func TestRunTestOnce_FailOnWrongStatus(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+	r.GET("/ping", func(c *hypcontext.Context) {
+		c.JSON(200, nil)
+	})
+
+	pass, reason := runTestOnce(r, TestCase{
+		Route:        "GET /ping",
+		ExpectStatus: 500, // 故意錯誤
+	})
+	if pass {
+		t.Error("runTestOnce should fail when status does not match")
+	}
+	if reason == "" {
+		t.Error("reason should not be empty on failure")
+	}
+}
+
+func TestRunTestOnce_InvalidRouteFormat(t *testing.T) {
+	r := router.New()
+	pass, reason := runTestOnce(r, TestCase{Route: "INVALID"})
+	if pass {
+		t.Error("invalid route format should fail")
+	}
+	if reason == "" {
+		t.Error("reason should describe the invalid format")
+	}
+}
+
+// ─── TestAll 向後相容 ─────────────────────────────────────────────────────────
+
+func TestTestAll_BackwardCompat(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+	r.Schema(schema.Route{
+		Method:  "GET",
+		Path:    "/compat",
+		Summary: "backward compat test",
+	}).Handle(func(c *hypcontext.Context) {
+		c.JSON(200, nil)
+	})
+
+	// TestAll(t, r) 不帶 RunConfig 應正常執行
+	TestAll(t, r)
+}
+
+// ─── 重試機制 ─────────────────────────────────────────────────────────────────
+
+func TestTestAll_RetrySucceeds(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	var callCount atomic.Int32
+
+	r.Schema(schema.Route{
+		Method:  "GET",
+		Path:    "/flaky",
+		Summary: "flaky route",
+	}).Handle(func(c *hypcontext.Context) {
+		n := callCount.Add(1)
+		if n < 3 {
+			// 前 2 次回傳 500
+			c.JSON(500, map[string]string{"error": "not ready"})
+			return
+		}
+		c.JSON(200, nil)
+	})
+
+	// RetryCount=3：最多執行 4 次（1 次初始 + 3 次重試）
+	// handler 第 3 次才回 200，在重試窗口內，應整體通過
+	TestAll(t, r, RunConfig{RetryCount: 3, RetryDelay: 0})
+
+	got := callCount.Load()
+	if got < 3 {
+		t.Errorf("handler called %d times, expected at least 3", got)
+	}
+}
+
+func TestObserve_RetrySucceeds(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	var callCount atomic.Int32
+
+	r.Schema(schema.Route{
+		Method:  "GET",
+		Path:    "/flaky2",
+		Summary: "flaky observe route",
+	}).Handle(func(c *hypcontext.Context) {
+		n := callCount.Add(1)
+		if n < 2 {
+			c.JSON(500, nil)
+			return
+		}
+		c.JSON(200, nil)
+	})
+
+	results := ObserveAll(t, r, ObserveOptions{
+		Silent: true,
+		Run:    RunConfig{RetryCount: 3, RetryDelay: 0},
+	})
+
+	if len(results) == 0 {
+		t.Fatal("expected at least 1 result")
+	}
+	if !results[0].Pass {
+		t.Errorf("result should pass after retry, FailReason: %s", results[0].FailReason)
+	}
+	if callCount.Load() < 2 {
+		t.Errorf("handler called %d times, expected at least 2", callCount.Load())
+	}
+}
+
+// ─── FailFast ─────────────────────────────────────────────────────────────────
+
+func TestObserve_FailFast_StopsEarly(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	var executedCount atomic.Int32
+
+	makeHandler := func(status int) hypcontext.HandlerFunc {
+		return func(c *hypcontext.Context) {
+			executedCount.Add(1)
+			c.JSON(status, nil)
+		}
+	}
+
+	// 路由 A：回傳 500（schema 期望 200），會失敗
+	r.Schema(schema.Route{Method: "GET", Path: "/a-fails", Summary: "fails"}).
+		Handle(makeHandler(500))
+	// 路由 B、C：正常（但 FailFast 後不應被執行）
+	r.Schema(schema.Route{Method: "GET", Path: "/b-ok", Summary: "ok"}).
+		Handle(makeHandler(200))
+	r.Schema(schema.Route{Method: "GET", Path: "/c-ok", Summary: "ok2"}).
+		Handle(makeHandler(200))
+
+	results := ObserveAll(t, r, ObserveOptions{
+		Silent: true,
+		Run:    RunConfig{FailFast: true},
+	})
+
+	// FailFast 應在第一個失敗後停止，results 數量應少於 3
+	if len(results) >= 3 {
+		t.Errorf("FailFast should stop early, got %d results (want < 3)", len(results))
+	}
+	// 至少有一個失敗結果
+	hasFailure := false
+	for _, r := range results {
+		if !r.Pass {
+			hasFailure = true
+			break
+		}
+	}
+	if !hasFailure {
+		t.Error("expected at least one failure result when FailFast triggered")
+	}
+}
+
+// ─── 速率限制 ─────────────────────────────────────────────────────────────────
+
+func TestObserve_RateLimit_SlowsExecution(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	for _, p := range []string{"/r1", "/r2", "/r3"} {
+		path := p
+		r.Schema(schema.Route{Method: "GET", Path: path, Summary: path}).
+			Handle(func(c *hypcontext.Context) { c.JSON(200, nil) })
+	}
+
+	// RateLimit=2 tests/sec：3 條路由之間有 2 次 sleep(500ms)
+	// 循序模式下執行：第 1 條前無 sleep，第 2 條前 sleep 500ms，第 3 條前 sleep 500ms
+	// 總耗時應 ≥ ~1s
+	start := time.Now()
+	ObserveAll(t, r, ObserveOptions{
+		Silent: true,
+		Run:    RunConfig{RateLimit: 2},
+	})
+	elapsed := time.Since(start)
+
+	// 3 條路由、RateLimit=2：應有 2 次 500ms 的速率限制等待 → ≥ ~900ms
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("rate limited run took %v, expected >= 900ms for 3 routes at 2/s", elapsed)
+	}
+}
+
+// ─── 並行加速 ────────────────────────────────────────────────────────────────
+
+func TestObserve_Parallel_FasterThanSequential(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing-sensitive test in short mode")
+	}
+
+	schema.Global().Reset()
+	r := router.New()
+
+	// 4 條路由，每條 handler 各 sleep 60ms
+	for _, p := range []string{"/p1", "/p2", "/p3", "/p4"} {
+		path := p
+		r.Schema(schema.Route{Method: "GET", Path: path, Summary: path}).
+			Handle(func(c *hypcontext.Context) {
+				time.Sleep(60 * time.Millisecond)
+				c.JSON(200, nil)
+			})
+	}
+
+	// 循序：預期 ~240ms
+	start := time.Now()
+	ObserveAll(t, r, ObserveOptions{Silent: true})
+	seqDur := time.Since(start)
+
+	// 並行（4 workers）：預期 ~60ms
+	start = time.Now()
+	ObserveAll(t, r, ObserveOptions{
+		Silent: true,
+		Run:    RunConfig{Parallel: true, MaxWorkers: 4},
+	})
+	parDur := time.Since(start)
+
+	// 並行應比循序快至少 40%
+	threshold := time.Duration(float64(seqDur) * 0.6)
+	if parDur >= threshold {
+		t.Errorf("parallel (%v) should be faster than 60%% of sequential (%v = threshold %v)",
+			parDur, seqDur, threshold)
+	}
+}
+
+// ─── 並行結果完整性 ───────────────────────────────────────────────────────────
+
+func TestObserve_Parallel_AllResultsCollected(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	for _, p := range []string{"/pa", "/pb", "/pc"} {
+		path := p
+		r.Schema(schema.Route{Method: "GET", Path: path, Summary: path}).
+			Handle(func(c *hypcontext.Context) { c.JSON(200, nil) })
+	}
+
+	results := ObserveAll(t, r, ObserveOptions{
+		Silent: true,
+		Run:    RunConfig{Parallel: true, MaxWorkers: 3},
+	})
+
+	if len(results) != 3 {
+		t.Errorf("parallel mode should collect all 3 results, got %d", len(results))
+	}
+	for _, res := range results {
+		if res.Route.Path == "" {
+			t.Error("result should have non-empty Route.Path")
+		}
+		if res.Response.StatusCode == 0 {
+			t.Error("result should have non-zero StatusCode")
+		}
+	}
+}
+
+// ─── TestAll + 並行 ────────────────────────────────────────────────────────────
+
+func TestTestAll_Parallel(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	for _, p := range []string{"/q1", "/q2", "/q3", "/q4"} {
+		path := p
+		r.Schema(schema.Route{Method: "GET", Path: path, Summary: path}).
+			Handle(func(c *hypcontext.Context) { c.JSON(200, nil) })
+	}
+
+	// 驗證並行模式不會 panic 且所有子測試通過
+	TestAll(t, r, RunConfig{Parallel: true, MaxWorkers: 4})
+}
+
+// ─── ObserveOptions.Run 零值向後相容 ──────────────────────────────────────────
+
+func TestObserve_ZeroRunConfig_BackwardCompat(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+	r.Schema(schema.Route{Method: "GET", Path: "/compat2", Summary: "compat"}).
+		Handle(func(c *hypcontext.Context) { c.JSON(200, nil) })
+
+	// ObserveOptions 不設定 Run 欄位 → 使用零值 RunConfig → 原有行為
+	results := ObserveAll(t, r, ObserveOptions{Silent: true})
+	if len(results) == 0 {
+		t.Error("expected results even with zero RunConfig")
+	}
+}
+
+// ─── RecordHistory ────────────────────────────────────────────────────────────
+
+func TestTestAll_RecordHistory_WritesJSONL(t *testing.T) {
+	schema.Global().Reset()
+	r := router.New()
+
+	r.Schema(schema.Route{Method: "GET", Path: "/hist1", Summary: "history test 1"}).
+		Handle(func(c *hypcontext.Context) { c.JSON(200, nil) })
+	r.Schema(schema.Route{Method: "POST", Path: "/hist2", Summary: "history test 2"}).
+		Handle(func(c *hypcontext.Context) { c.JSON(201, nil) })
+
+	// 使用臨時目錄，切換工作目錄使 .hyp/ 寫入到 tmpDir
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// RecordHistory=true：應在 .hyp/eval_history.jsonl 中寫入 2 筆記錄
+	TestAll(t, r, RunConfig{RecordHistory: true})
+
+	histPath := filepath.Join(tmpDir, eval.DefaultHistoryPath())
+	records, loadErr := eval.LoadHistory(histPath)
+	if loadErr != nil {
+		t.Fatalf("LoadHistory failed: %v", loadErr)
+	}
+	if len(records) != 2 {
+		t.Errorf("expected 2 history records, got %d", len(records))
+	}
+	for _, rec := range records {
+		if rec.Status == "" {
+			t.Error("record.Status should not be empty")
+		}
+		if rec.LatencyMs < 0 {
+			t.Errorf("record.LatencyMs = %d, want >= 0", rec.LatencyMs)
+		}
+		if rec.Scores["contract"] != 1.0 {
+			t.Errorf("record.Scores[contract] = %f, want 1.0 for passing route", rec.Scores["contract"])
+		}
+	}
+}
+
+func TestTestAll_RecordHistory_FailAndPassRecords(t *testing.T) {
+	// 直接驗證 eval.AppendHistoryTo 可同時正確記錄 status=fail/pass 與對應分數
+	// 不透過 TestAll（避免失敗子測試汙染 t），在 eval 層面驗證記錄格式往返
+	tmpDir := t.TempDir()
+	histPath := filepath.Join(tmpDir, "eval_roundtrip.jsonl")
+
+	records := []eval.EvalRecord{
+		{
+			Timestamp:  time.Now().UTC(),
+			Route:      "GET /hist-fail",
+			Status:     "fail",
+			Scores:     map[string]float64{"contract": 0.0},
+			LatencyMs:  1,
+			FailReason: "[GET /hist-fail] status = 500, want 200",
+		},
+		{
+			Timestamp: time.Now().UTC(),
+			Route:     "GET /hist-pass",
+			Status:    "pass",
+			Scores:    map[string]float64{"contract": 1.0},
+			LatencyMs: 5,
+		},
+	}
+
+	for _, rec := range records {
+		if err := eval.AppendHistoryTo(histPath, rec); err != nil {
+			t.Fatalf("AppendHistoryTo: %v", err)
+		}
+	}
+
+	loaded, err := eval.LoadHistory(histPath)
+	if err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Errorf("expected 2 records, got %d", len(loaded))
+	}
+	if loaded[0].Status != "fail" || loaded[0].Scores["contract"] != 0.0 {
+		t.Errorf("loaded[0]: status=%q scores=%v, want status=fail contract=0.0",
+			loaded[0].Status, loaded[0].Scores)
+	}
+	if loaded[0].FailReason == "" {
+		t.Error("loaded[0].FailReason should not be empty for a failing record")
+	}
+	if loaded[1].Status != "pass" || loaded[1].Scores["contract"] != 1.0 {
+		t.Errorf("loaded[1]: status=%q scores=%v, want status=pass contract=1.0",
+			loaded[1].Status, loaded[1].Scores)
+	}
+}
+
+func TestMergeRunConfig_RecordHistory_DefaultFalse(t *testing.T) {
+	cfg := mergeRunConfig(nil)
+	if cfg.RecordHistory {
+		t.Error("RecordHistory should default to false")
+	}
+}
+
+func TestMergeRunConfig_RecordHistory_Explicit(t *testing.T) {
+	cfg := mergeRunConfig([]RunConfig{{RecordHistory: true}})
+	if !cfg.RecordHistory {
+		t.Error("RecordHistory should be true when explicitly set")
+	}
+}

--- a/pkg/contract/observe.go
+++ b/pkg/contract/observe.go
@@ -1,7 +1,7 @@
 package contract
 
 // @ai purpose: Test Observe — 以完整 HTTP 捕捉模式執行 contract 測試，並生成結構化 HTML 報告
-// @ai input: *testing.T, *router.Router, 可選的函式名稱過濾字串與 ObserveOptions
+// @ai input: *testing.T, *router.Router, 可選的函式名稱過濾字串與 ObserveOptions（含 RunConfig）
 // @ai output: []ObserveResult（每條路由一筆完整記錄），並將 HTML 報告寫入 .hyp/observe_*.html
 // @ai sideeffect: 建立 .hyp/ 目錄、寫入 HTML 報告檔案、可選擇自動開啟瀏覽器
 // date: 2026-05-23
@@ -15,6 +15,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,6 +36,10 @@ type ObserveOptions struct {
 
 	// Silent 抑制 t.Logf 的報告路徑輸出
 	Silent bool
+
+	// Run 配置執行引擎（並行、重試、速率限制、FailFast）
+	// 零值等同原有行為（循序、不重試、不限速、不 FailFast）
+	Run RunConfig
 }
 
 // CapturedRequest 記錄實際發出的 HTTP 請求完整內容
@@ -82,6 +88,18 @@ type ObserveResult struct {
 //	func TestObserveWithBrowser(t *testing.T) {
 //	    contract.ObserveAll(t, setupRouter(), contract.ObserveOptions{OpenBrowser: true})
 //	}
+//
+//	func TestObserveParallel(t *testing.T) {
+//	    contract.ObserveAll(t, setupRouter(), contract.ObserveOptions{
+//	        Run: contract.RunConfig{Parallel: true, MaxWorkers: 4, RetryCount: 2},
+//	    })
+//	}
+//
+// @ai purpose: 觀察所有 schema-registered REST 路由，捕捉完整 HTTP 交換並生成 HTML 報告
+// @ai input: *testing.T（可為 nil）、*hypRouter.Router、可選的 ObserveOptions
+// @ai output: []ObserveResult（每條路由一筆完整記錄）
+// @ai sideeffect: 建立 .hyp/ 目錄、寫入 HTML 報告、可開啟瀏覽器
+// date: 2026-05-23
 func ObserveAll(t *testing.T, r *hypRouter.Router, opts ...ObserveOptions) []ObserveResult {
 	if t != nil {
 		t.Helper()
@@ -103,6 +121,12 @@ func ObserveAll(t *testing.T, r *hypRouter.Router, opts ...ObserveOptions) []Obs
 //	func TestObserveOrders(t *testing.T) {
 //	    contract.Observe(t, setupRouter(), "orders")
 //	}
+//
+// @ai purpose: 依過濾條件觀察特定路由，支援 HandlerNames / Path / Summary / Tags 比對
+// @ai input: *testing.T（可為 nil）、*hypRouter.Router、funcName string（過濾條件）、可選的 ObserveOptions
+// @ai output: []ObserveResult（符合過濾條件的路由記錄）
+// @ai sideeffect: 建立 .hyp/ 目錄、寫入 HTML 報告、可開啟瀏覽器
+// date: 2026-05-23
 func Observe(t *testing.T, r *hypRouter.Router, funcName string, opts ...ObserveOptions) []ObserveResult {
 	if t != nil {
 		t.Helper()
@@ -111,6 +135,13 @@ func Observe(t *testing.T, r *hypRouter.Router, funcName string, opts ...Observe
 }
 
 // runObserve 為 ObserveAll 和 Observe 的共用內部實作
+// 支援循序與並行兩種執行路徑，均透過 writeObserveReport 輸出 HTML 報告
+//
+// @ai purpose: 整合路由過濾、執行引擎（RunConfig）、結果收集、HTML 報告寫入
+// @ai input: *testing.T、*hypRouter.Router、filter string、ObserveOptions
+// @ai output: []ObserveResult
+// @ai sideeffect: 可能建立 .hyp/ 目錄並寫入 HTML 檔案
+// date: 2026-05-23
 func runObserve(t *testing.T, r *hypRouter.Router, filter string, opt ObserveOptions) []ObserveResult {
 	routes := schema.Global().All()
 	if len(routes) == 0 {
@@ -120,7 +151,8 @@ func runObserve(t *testing.T, r *hypRouter.Router, filter string, opt ObserveOpt
 		return nil
 	}
 
-	var results []ObserveResult
+	// 過濾出符合條件的 REST 路由
+	var targets []schema.Route
 	for _, route := range routes {
 		if !route.IsREST() {
 			continue
@@ -128,17 +160,137 @@ func runObserve(t *testing.T, r *hypRouter.Router, filter string, opt ObserveOpt
 		if filter != "" && !observeRouteMatchesFilter(route, filter) {
 			continue
 		}
-		results = append(results, captureRouteExchange(r, route))
+		targets = append(targets, route)
 	}
 
-	if len(results) == 0 {
+	if len(targets) == 0 {
 		if t != nil {
 			t.Logf("[observe] no routes matched filter %q", filter)
 		}
+		return nil
+	}
+
+	cfg := opt.Run
+	// 防禦性檢查：MaxWorkers 在 mergeObserveOpts 不做正規化，在此補齊
+	if cfg.MaxWorkers <= 0 {
+		cfg.MaxWorkers = runtime.GOMAXPROCS(0)
+	}
+
+	// ── 並行路徑 ──────────────────────────────────────────────────────────
+	if cfg.Parallel && len(targets) > 1 {
+		sem := make(chan struct{}, cfg.MaxWorkers)
+		var (
+			mu      sync.Mutex
+			wg      sync.WaitGroup
+			aborted atomic.Bool
+			results []ObserveResult
+		)
+
+		// 速率限制器
+		var limiterCh <-chan time.Time
+		if cfg.RateLimit > 0 {
+			ticker := time.NewTicker(time.Second / time.Duration(cfg.RateLimit))
+			limiterCh = ticker.C
+			defer ticker.Stop()
+		}
+
+		for _, route := range targets {
+			if aborted.Load() {
+				break
+			}
+			route := route // capture
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// 獲取 semaphore slot（控制最大並行數）
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				// 再次檢查：獲取 slot 後可能已有其他 goroutine 設定 FailFast
+				if aborted.Load() {
+					return
+				}
+
+				// 速率限制
+				if cfg.RateLimit > 0 {
+					<-limiterCh
+				}
+
+				result := captureWithRetry(r, route, cfg)
+
+				mu.Lock()
+				results = append(results, result)
+				mu.Unlock()
+
+				if !result.Pass && cfg.FailFast {
+					aborted.Store(true)
+				}
+			}()
+		}
+		wg.Wait()
+
+		return writeObserveReport(t, results, filter, opt)
+	}
+
+	// ── 循序路徑（預設）──────────────────────────────────────────────────
+	var results []ObserveResult
+	var seqAborted bool
+
+	for _, route := range targets {
+		if cfg.FailFast && seqAborted {
+			break
+		}
+		// 循序速率限制：兩次執行間 sleep
+		if cfg.RateLimit > 0 {
+			time.Sleep(time.Second / time.Duration(cfg.RateLimit))
+		}
+		result := captureWithRetry(r, route, cfg)
+		results = append(results, result)
+		if !result.Pass && cfg.FailFast {
+			seqAborted = true
+		}
+	}
+
+	return writeObserveReport(t, results, filter, opt)
+}
+
+// captureWithRetry 執行帶重試機制的 captureRouteExchange
+// 失敗時最多重試 cfg.RetryCount 次，回傳最後一次的完整記錄
+//
+// @ai purpose: 讓 Observe 模式也能受益於 RunConfig 的重試設定
+// @ai input: *hypRouter.Router、schema.Route、RunConfig（重試設定）
+// @ai output: ObserveResult（最後一次執行的完整記錄）
+// @ai sideeffect: 無（不接觸 *testing.T）
+// date: 2026-05-23
+func captureWithRetry(r *hypRouter.Router, route schema.Route, cfg RunConfig) ObserveResult {
+	var result ObserveResult
+	for attempt := 0; attempt <= cfg.RetryCount; attempt++ {
+		if attempt > 0 && cfg.RetryDelay > 0 {
+			time.Sleep(cfg.RetryDelay)
+		}
+		result = captureRouteExchange(r, route)
+		if result.Pass {
+			break
+		}
+	}
+	return result
+}
+
+// writeObserveReport 將結果列表寫入 HTML 報告並回傳結果
+// 提取為獨立函式以消除循序/並行兩條路徑的重複邏輯
+//
+// @ai purpose: 統一處理 HTML 報告生成、檔案寫入、瀏覽器開啟
+// @ai input: *testing.T（可為 nil）、[]ObserveResult、filter string、ObserveOptions
+// @ai output: []ObserveResult（原樣回傳，供呼叫端程式化斷言）
+// @ai sideeffect: 建立 .hyp/ 目錄、寫入 HTML 檔案、可開啟瀏覽器
+// date: 2026-05-23
+func writeObserveReport(t *testing.T, results []ObserveResult, filter string, opt ObserveOptions) []ObserveResult {
+	if len(results) == 0 {
 		return results
 	}
 
-	// 寫入 HTML 報告
 	outPath := opt.OutputPath
 	if outPath == "" {
 		if err := os.MkdirAll(".hyp", 0o755); err == nil {
@@ -147,8 +299,8 @@ func runObserve(t *testing.T, r *hypRouter.Router, filter string, opt ObserveOpt
 		}
 	}
 	if outPath != "" {
-		html := GenerateObserveHTML(results, filter)
-		if err := os.WriteFile(outPath, []byte(html), 0o644); err == nil {
+		htmlContent := GenerateObserveHTML(results, filter)
+		if err := os.WriteFile(outPath, []byte(htmlContent), 0o644); err == nil {
 			if t != nil && !opt.Silent {
 				t.Logf("[observe] report → %s", outPath)
 			}
@@ -162,6 +314,12 @@ func runObserve(t *testing.T, r *hypRouter.Router, filter string, opt ObserveOpt
 }
 
 // captureRouteExchange 執行一條路由的測試並捕捉完整的 HTTP 交換記錄
+//
+// @ai purpose: 捕捉單一路由的完整 HTTP 請求/回應，並執行四步驗證
+// @ai input: *hypRouter.Router、schema.Route
+// @ai output: ObserveResult（含完整 HTTP 交換記錄與驗證步驟）
+// @ai sideeffect: 無（httptest 模式，不開真實 port）
+// date: 2026-05-23
 func captureRouteExchange(r *hypRouter.Router, route schema.Route) ObserveResult {
 	tc := generateTestCase(route)
 	tc.schemaPath = route.Path
@@ -230,6 +388,12 @@ func captureRouteExchange(r *hypRouter.Router, route schema.Route) ObserveResult
 }
 
 // runObserveValidation 逐步執行驗證並記錄每個步驟的結果
+//
+// @ai purpose: 四步驗證（狀態碼、回應 body 非空、Input schema、Output schema）
+// @ai input: schema.Route、TestCase（自動生成）、實際 HTTP 狀態碼、回應 body
+// @ai output: []ValidationStep、pass bool、reason string
+// @ai sideeffect: 無
+// date: 2026-05-23
 func runObserveValidation(route schema.Route, tc TestCase, code int, body []byte) (steps []ValidationStep, pass bool, reason string) {
 	pass = true
 
@@ -303,6 +467,12 @@ func runObserveValidation(route schema.Route, tc TestCase, code int, body []byte
 
 // observeRouteMatchesFilter 判斷路由是否符合過濾字串
 // 對 HandlerNames、Path、Summary、Tags 做大小寫不敏感的子字串比對
+//
+// @ai purpose: 讓 Observe(t, r, "funcName") 可以依多個維度過濾路由
+// @ai input: schema.Route、filter string
+// @ai output: bool（是否符合）
+// @ai sideeffect: 無
+// date: 2026-05-23
 func observeRouteMatchesFilter(route schema.Route, filter string) bool {
 	f := strings.ToLower(filter)
 	for _, h := range route.HandlerNames {
@@ -325,6 +495,12 @@ func observeRouteMatchesFilter(route schema.Route, filter string) bool {
 }
 
 // mergeObserveOpts 取第一個 ObserveOptions 或回傳預設值
+//
+// @ai purpose: 讓 ObserveAll(t, r) 零引數呼叫繼續向後相容
+// @ai input: []ObserveOptions
+// @ai output: ObserveOptions（第一個或零值）
+// @ai sideeffect: 無
+// date: 2026-05-23
 func mergeObserveOpts(opts []ObserveOptions) ObserveOptions {
 	if len(opts) > 0 {
 		return opts[0]
@@ -333,6 +509,12 @@ func mergeObserveOpts(opts []ObserveOptions) ObserveOptions {
 }
 
 // observeIfElse 為內部使用的三元表達式替代
+//
+// @ai purpose: 消除 if/else 的樣板程式碼
+// @ai input: cond bool、t string（true 時回傳）、f string（false 時回傳）
+// @ai output: string
+// @ai sideeffect: 無
+// date: 2026-05-23
 func observeIfElse(cond bool, t, f string) string {
 	if cond {
 		return t
@@ -341,6 +523,12 @@ func observeIfElse(cond bool, t, f string) string {
 }
 
 // openObserveBrowser 在預設瀏覽器中開啟指定路徑的 HTML 報告
+//
+// @ai purpose: 跨平台開啟瀏覽器（macOS / Linux / Windows）
+// @ai input: path string（HTML 報告的相對或絕對路徑）
+// @ai output: 無
+// @ai sideeffect: 啟動系統瀏覽器程序
+// date: 2026-05-23
 func openObserveBrowser(path string) {
 	abs, err := filepath.Abs(path)
 	if err != nil {

--- a/pkg/eval/history.go
+++ b/pkg/eval/history.go
@@ -1,0 +1,198 @@
+package eval
+
+// @ai purpose: Evaluation History 持久化 — 將 contract 測試結果以 JSONL 格式 append 到 .hyp/eval_history.jsonl
+// @ai input: EvalRecord（測試結果結構）、可選的自訂路徑
+// @ai output: 錯誤（nil 表示成功）
+// @ai sideeffect: 建立 .hyp/ 目錄、讀寫 .hyp/eval_history.jsonl（原子替換：寫 .tmp → rename）
+// date: 2026-05-23
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// EvalRecord 記錄單一測試案例的完整執行結果
+// 對應 .hyp/eval_history.jsonl 中的每一行 JSON
+//
+// @ai purpose: 標準化測試結果的持久化格式，供後續趨勢分析與品質追蹤使用
+// @ai input: none（純資料結構）
+// @ai output: none（純資料結構）
+// @ai sideeffect: none
+// date: 2026-05-23
+type EvalRecord struct {
+	// Timestamp 為測試執行時間（UTC）
+	Timestamp time.Time `json:"ts"`
+
+	// GitCommit 為當前 git 短 hash（如 "a3f8b21"），無法取得時為空字串
+	GitCommit string `json:"git_commit,omitempty"`
+
+	// Route 為 "METHOD /path" 格式，例如 "POST /api/summarize"
+	Route string `json:"route"`
+
+	// Status 為 "pass" 或 "fail"
+	Status string `json:"status"`
+
+	// Scores 為各評判器的評分（0.0–1.0），目前只有 "contract" 分數
+	// 未來 Item A（Probabilistic Evaluation）加入後將包含 "llm_judge"、"similarity" 等
+	Scores map[string]float64 `json:"scores,omitempty"`
+
+	// LatencyMs 為完整執行時間（含重試），單位毫秒
+	LatencyMs int64 `json:"latency_ms"`
+
+	// InputHash 為請求 body 的 sha256 前綴（格式 "sha256:abcdef01"）
+	// 只存 hash，不存實際輸入，避免敏感資料洩漏
+	InputHash string `json:"input_hash,omitempty"`
+
+	// FailReason 為失敗原因字串，pass 時為空
+	FailReason string `json:"fail_reason,omitempty"`
+}
+
+// historyMu 保護同一進程內對 history 檔案的並行寫入
+var historyMu sync.Mutex
+
+// DefaultHistoryPath 回傳預設的 history 檔案路徑
+//
+// @ai purpose: 集中管理 history 檔案路徑，讓呼叫者不需硬編碼路徑字串
+// @ai input: none
+// @ai output: .hyp/eval_history.jsonl 的相對路徑字串
+// @ai sideeffect: none
+// date: 2026-05-23
+func DefaultHistoryPath() string {
+	return filepath.Join(".hyp", "eval_history.jsonl")
+}
+
+// HashInput 計算請求 body 的 sha256 前綴摘要
+// 格式：「sha256:」+ 前 8 bytes 的 hex（16 字元）
+// 空字串輸入回傳空字串（不記錄）
+//
+// @ai purpose: 在不儲存實際輸入內容的前提下，唯一識別相同的 test input，供重複性分析使用
+// @ai input: 請求 body 字串（可為空）
+// @ai output: "sha256:前8bytes的hex" 或空字串
+// @ai sideeffect: none
+// date: 2026-05-23
+func HashInput(input string) string {
+	if input == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("sha256:%x", h[:8])
+}
+
+// GitShortCommit 取得目前 git 倉庫的短 commit hash（7 字元）
+// 若 git 不可用或不在 git 倉庫中，回傳空字串（不中止程式）
+//
+// @ai purpose: 將測試結果與 git 版本關聯，讓趨勢報告可追蹤品質與程式碼版本的對應關係
+// @ai input: none（從當前工作目錄執行 git 命令）
+// @ai output: 7 字元短 commit hash 或空字串（git 不可用時）
+// @ai sideeffect: 呼叫 git rev-parse --short HEAD 子程序
+// date: 2026-05-23
+func GitShortCommit() string {
+	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// AppendHistory 將一筆 EvalRecord append 到預設 history 檔案（DefaultHistoryPath()）
+// 採原子替換（讀取現有內容 → 寫入暫存 .tmp → rename），不會在寫入中途損壞檔案
+// 若 .hyp/ 目錄不存在則自動建立
+//
+// @ai purpose: 讓 TestAll 可以在不修改原始碼的情況下持久化測試結果，支援未來的趨勢分析
+// @ai input: EvalRecord（單一測試結果）
+// @ai output: 錯誤（nil 表示成功）
+// @ai sideeffect: 讀寫 .hyp/eval_history.jsonl 與暫存 .tmp 檔案
+// date: 2026-05-23
+func AppendHistory(record EvalRecord) error {
+	return AppendHistoryTo(DefaultHistoryPath(), record)
+}
+
+// AppendHistoryTo 將一筆 EvalRecord append 到指定路徑
+// 功能與 AppendHistory 相同，但接受自訂路徑，方便測試使用暫存目錄
+//
+// @ai purpose: 提供可測試版本的 AppendHistory，讓測試可指定路徑而不影響真實 .hyp/ 目錄
+// @ai input: path string（目標 JSONL 路徑）、EvalRecord（資料）
+// @ai output: 錯誤（nil 表示成功）
+// @ai sideeffect: 讀寫指定路徑與暫存 .tmp 檔案
+// date: 2026-05-23
+func AppendHistoryTo(path string, record EvalRecord) error {
+	historyMu.Lock()
+	defer historyMu.Unlock()
+
+	// 確保目錄存在
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("eval: mkdir %s: %w", dir, err)
+	}
+
+	// 序列化新紀錄為一行 JSON
+	line, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("eval: marshal record: %w", err)
+	}
+	line = append(line, '\n')
+
+	// 讀取現有內容（若檔案不存在則視為空）
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("eval: read history: %w", err)
+	}
+
+	// 合併現有內容 + 新紀錄
+	combined := make([]byte, 0, len(existing)+len(line))
+	combined = append(combined, existing...)
+	combined = append(combined, line...)
+
+	// 原子寫入：先寫暫存檔，成功後 rename
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, combined, 0o644); err != nil {
+		return fmt.Errorf("eval: write temp %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp) // 清理暫存檔，忽略錯誤
+		return fmt.Errorf("eval: rename to %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// LoadHistory 從 JSONL 檔案讀取所有 EvalRecord
+// 若檔案不存在，回傳 nil slice（非錯誤）
+// 跳過格式錯誤的行，不中止整個讀取
+//
+// @ai purpose: 讓 hyp eval-report 與未來的趨勢分析工具讀取歷史測試結果
+// @ai input: path string（JSONL 檔案路徑，通常為 DefaultHistoryPath()）
+// @ai output: []EvalRecord（若檔案不存在為 nil）、錯誤
+// @ai sideeffect: 讀取指定檔案
+// date: 2026-05-23
+func LoadHistory(path string) ([]EvalRecord, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("eval: read history %s: %w", path, err)
+	}
+
+	var records []EvalRecord
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var r EvalRecord
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			// 跳過格式錯誤的行（可能由截斷寫入產生）
+			continue
+		}
+		records = append(records, r)
+	}
+	return records, nil
+}

--- a/pkg/eval/history_test.go
+++ b/pkg/eval/history_test.go
@@ -1,0 +1,338 @@
+package eval
+
+// @ai purpose: history_test — 驗證 EvalRecord 序列化、AppendHistory 原子寫入、LoadHistory 解析、HashInput 與 GitShortCommit
+// @ai input: *testing.T
+// @ai output: 無
+// @ai sideeffect: 在測試暫存目錄中建立 eval_history.jsonl 與 .tmp 暫存檔
+// date: 2026-05-23
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ─── DefaultHistoryPath ───────────────────────────────────────────────────────
+
+func TestDefaultHistoryPath(t *testing.T) {
+	p := DefaultHistoryPath()
+	if !strings.Contains(p, "eval_history.jsonl") {
+		t.Errorf("DefaultHistoryPath = %q, should contain eval_history.jsonl", p)
+	}
+	if !strings.Contains(p, ".hyp") {
+		t.Errorf("DefaultHistoryPath = %q, should contain .hyp directory", p)
+	}
+}
+
+// ─── HashInput ────────────────────────────────────────────────────────────────
+
+func TestHashInput_Empty(t *testing.T) {
+	if got := HashInput(""); got != "" {
+		t.Errorf("HashInput(\"\") = %q, want empty string", got)
+	}
+}
+
+func TestHashInput_NonEmpty(t *testing.T) {
+	got := HashInput(`{"name":"test"}`)
+	if !strings.HasPrefix(got, "sha256:") {
+		t.Errorf("HashInput should start with sha256:, got %q", got)
+	}
+	// sha256: + 8 bytes * 2 hex chars = sha256: + 16 chars = 23 chars total
+	if len(got) != 23 {
+		t.Errorf("HashInput length = %d, want 23", len(got))
+	}
+}
+
+func TestHashInput_Deterministic(t *testing.T) {
+	input := `{"key":"value"}`
+	h1 := HashInput(input)
+	h2 := HashInput(input)
+	if h1 != h2 {
+		t.Errorf("HashInput not deterministic: %q != %q", h1, h2)
+	}
+}
+
+func TestHashInput_DifferentInputsDifferentHashes(t *testing.T) {
+	h1 := HashInput(`{"a":1}`)
+	h2 := HashInput(`{"a":2}`)
+	if h1 == h2 {
+		t.Error("different inputs should produce different hashes")
+	}
+}
+
+// ─── GitShortCommit ───────────────────────────────────────────────────────────
+
+func TestGitShortCommit_DoesNotPanic(t *testing.T) {
+	// 不論是否在 git 倉庫中，都不應該 panic
+	got := GitShortCommit()
+	// 若在 git 倉庫中，長度應為 7；若不在則為空字串
+	if len(got) != 0 && len(got) != 7 {
+		t.Logf("GitShortCommit = %q (length %d, expected 0 or 7)", got, len(got))
+	}
+}
+
+// ─── AppendHistoryTo ─────────────────────────────────────────────────────────
+
+func TestAppendHistory_CreatesDirectoryAndFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sub", "eval.jsonl")
+
+	record := EvalRecord{
+		Timestamp: time.Now().UTC(),
+		Route:     "GET /test",
+		Status:    "pass",
+		LatencyMs: 5,
+	}
+
+	if err := AppendHistoryTo(path, record); err != nil {
+		t.Fatalf("AppendHistoryTo failed: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("history file should exist after append: %v", err)
+	}
+}
+
+func TestAppendHistory_SingleRecord(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "eval.jsonl")
+
+	record := EvalRecord{
+		Timestamp:  time.Date(2026, 5, 23, 14, 0, 0, 0, time.UTC),
+		GitCommit:  "a3f8b21",
+		Route:      "POST /api/users",
+		Status:     "pass",
+		Scores:     map[string]float64{"contract": 1.0},
+		LatencyMs:  42,
+		InputHash:  HashInput(`{"name":"test"}`),
+		FailReason: "",
+	}
+
+	if err := AppendHistoryTo(path, record); err != nil {
+		t.Fatalf("AppendHistoryTo failed: %v", err)
+	}
+
+	records, err := LoadHistory(path)
+	if err != nil {
+		t.Fatalf("LoadHistory failed: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+
+	got := records[0]
+	if got.Route != "POST /api/users" {
+		t.Errorf("Route = %q, want POST /api/users", got.Route)
+	}
+	if got.Status != "pass" {
+		t.Errorf("Status = %q, want pass", got.Status)
+	}
+	if got.GitCommit != "a3f8b21" {
+		t.Errorf("GitCommit = %q, want a3f8b21", got.GitCommit)
+	}
+	if got.LatencyMs != 42 {
+		t.Errorf("LatencyMs = %d, want 42", got.LatencyMs)
+	}
+	if got.Scores["contract"] != 1.0 {
+		t.Errorf("Scores[contract] = %f, want 1.0", got.Scores["contract"])
+	}
+}
+
+func TestAppendHistory_MultipleRecords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "eval.jsonl")
+
+	routes := []string{"GET /a", "POST /b", "DELETE /c"}
+	for _, route := range routes {
+		record := EvalRecord{
+			Timestamp: time.Now().UTC(),
+			Route:     route,
+			Status:    "pass",
+			LatencyMs: 10,
+		}
+		if err := AppendHistoryTo(path, record); err != nil {
+			t.Fatalf("AppendHistoryTo(%q) failed: %v", route, err)
+		}
+	}
+
+	records, err := LoadHistory(path)
+	if err != nil {
+		t.Fatalf("LoadHistory failed: %v", err)
+	}
+	if len(records) != 3 {
+		t.Errorf("expected 3 records, got %d", len(records))
+	}
+	for i, rec := range records {
+		if rec.Route != routes[i] {
+			t.Errorf("records[%d].Route = %q, want %q", i, rec.Route, routes[i])
+		}
+	}
+}
+
+func TestAppendHistory_NoTmpFileRemains(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "eval.jsonl")
+
+	if err := AppendHistoryTo(path, EvalRecord{
+		Timestamp: time.Now().UTC(),
+		Route:     "GET /ok",
+		Status:    "pass",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// .tmp 暫存檔不應遺留
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error(".tmp file should not remain after successful append")
+	}
+}
+
+// ─── AppendHistory 並行安全 ────────────────────────────────────────────────────
+
+func TestAppendHistory_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "eval_concurrent.jsonl")
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			record := EvalRecord{
+				Timestamp: time.Now().UTC(),
+				Route:     "GET /concurrent",
+				Status:    "pass",
+				LatencyMs: int64(n),
+			}
+			if err := AppendHistoryTo(path, record); err != nil {
+				t.Errorf("goroutine %d: AppendHistoryTo failed: %v", n, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	records, err := LoadHistory(path)
+	if err != nil {
+		t.Fatalf("LoadHistory after concurrent writes failed: %v", err)
+	}
+	if len(records) != goroutines {
+		t.Errorf("expected %d records after concurrent writes, got %d", goroutines, len(records))
+	}
+}
+
+// ─── LoadHistory ──────────────────────────────────────────────────────────────
+
+func TestLoadHistory_NonExistentFile(t *testing.T) {
+	records, err := LoadHistory(filepath.Join(t.TempDir(), "nonexistent.jsonl"))
+	if err != nil {
+		t.Errorf("LoadHistory non-existent file should not error, got: %v", err)
+	}
+	if records != nil {
+		t.Errorf("LoadHistory non-existent should return nil slice, got %v", records)
+	}
+}
+
+func TestLoadHistory_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := LoadHistory(path)
+	if err != nil {
+		t.Errorf("LoadHistory empty file should not error, got: %v", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("LoadHistory empty file should return 0 records, got %d", len(records))
+	}
+}
+
+func TestLoadHistory_SkipsMalformedLines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "malformed.jsonl")
+
+	content := `{"ts":"2026-05-23T14:00:00Z","route":"GET /ok","status":"pass","latency_ms":10}
+NOT_VALID_JSON
+{"ts":"2026-05-23T14:01:00Z","route":"POST /ok2","status":"fail","latency_ms":20}
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := LoadHistory(path)
+	if err != nil {
+		t.Fatalf("LoadHistory should not error on malformed line, got: %v", err)
+	}
+	// 只有 2 條有效記錄（中間那條被跳過）
+	if len(records) != 2 {
+		t.Errorf("expected 2 valid records (skip malformed), got %d", len(records))
+	}
+}
+
+func TestLoadHistory_PreservesOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "order.jsonl")
+
+	routes := []string{"GET /first", "POST /second", "DELETE /third"}
+	for _, r := range routes {
+		if err := AppendHistoryTo(path, EvalRecord{
+			Timestamp: time.Now().UTC(),
+			Route:     r,
+			Status:    "pass",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	records, err := LoadHistory(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, r := range records {
+		if r.Route != routes[i] {
+			t.Errorf("record[%d].Route = %q, want %q", i, r.Route, routes[i])
+		}
+	}
+}
+
+// ─── EvalRecord 欄位序列化 ─────────────────────────────────────────────────────
+
+func TestEvalRecord_OmitEmptyFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "omit.jsonl")
+
+	record := EvalRecord{
+		Timestamp: time.Now().UTC(),
+		Route:     "GET /minimal",
+		Status:    "pass",
+		LatencyMs: 1,
+		// GitCommit、InputHash、FailReason、Scores 全部為空/nil → omitempty
+	}
+	if err := AppendHistoryTo(path, record); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(path)
+	line := strings.TrimSpace(string(data))
+
+	// omitempty 欄位不應出現在 JSON 中
+	if strings.Contains(line, "git_commit") {
+		t.Error("git_commit should be omitted when empty")
+	}
+	if strings.Contains(line, "input_hash") {
+		t.Error("input_hash should be omitted when empty")
+	}
+	if strings.Contains(line, "fail_reason") {
+		t.Error("fail_reason should be omitted when empty")
+	}
+	if strings.Contains(line, "scores") {
+		t.Error("scores should be omitted when nil")
+	}
+}


### PR DESCRIPTION
…story persistence (Phase 1 v0.9.0)

Item B — Execution Engine (RunConfig):
- pkg/contract/engine.go: new RunConfig struct with Parallel, MaxWorkers, RetryCount, RetryDelay, RateLimit, FailFast, RecordHistory fields; mergeRunConfig() normalises zero values (MaxWorkers → GOMAXPROCS)
- pkg/contract/contract.go: extract runTestOnce() as pure function; TestAll() now accepts variadic RunConfig; parallel via t.Parallel(), rate limiter via time.Ticker + t.Cleanup, retry loop with t.Logf, FailFast via sync/atomic.Bool; git commit captured once before loop
- pkg/contract/observe.go: ObserveOptions gains Run RunConfig field; runObserve() has sequential and parallel paths (goroutine pool + semaphore + sync.WaitGroup + atomic.Bool for FailFast); captureWithRetry() extracted for reuse; writeObserveReport() deduplicates HTML write logic
- pkg/contract/engine_test.go: 19 tests covering mergeRunConfig defaults, runTestOnce pure function, backward compat, retry success, FailFast, RateLimit timing, parallel vs sequential throughput, RecordHistory roundtrip

Item C — Evaluation History persistence:
- pkg/eval/history.go: new package; EvalRecord struct (ts, git_commit, route, status, scores, latency_ms, input_hash, fail_reason); AppendHistory / AppendHistoryTo atomic write (temp + rename); LoadHistory skips malformed lines; HashInput sha256 prefix (never raw body); GitShortCommit subprocess; package-level sync.Mutex for concurrent safety
- pkg/eval/history_test.go: 16 tests including concurrent write safety, omitempty serialisation, malformed line skipping, order preservation
- cmd/hyp/eval_report.go: new `hyp eval-report` command; reads JSONL, groups by route, computes windowed averages, trend arrows (↑↓→), flaky detection (⚡), ⚠ on score drop > 0.1, tabwriter output
- cmd/hyp/main.go: register evalReportCmd